### PR TITLE
ATA `snap_feng_init` and `ata_snap_fengine` ease of use changes

### DIFF
--- a/sw/ata_snap/scripts/snap_feng_init.py
+++ b/sw/ata_snap/scripts/snap_feng_init.py
@@ -10,134 +10,162 @@ import struct
 
 from ata_snap import ata_snap_fengine
 
-parser = argparse.ArgumentParser(description='Program and initialize a SNAP ADC5G spectrometer',
+def run(host, fpgfile, configfile,
+        sync=False,
+        mansync=False,
+        tvg=False,
+        feng_id=0,
+        dest_port=None,
+        skipprog=False,
+        usetapcp=False,
+        eth_spec=False,
+        eth_volt=False,
+        acclen=None,
+        specdest=None
+        ):
+    logger = logging.getLogger(__file__)
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+    assert not (eth_spec and eth_volt), "Can't use both --eth_spec and --eth_volt options!"
+
+    # Load configuration file and override parameters with
+    # user flags
+    with open(configfile, 'r') as fh:
+        config = yaml.load(fh, Loader=yaml.SafeLoader)
+
+    config['acclen'] = acclen or config['acclen']
+    config['spectrometer_dest'] = specdest or config['spectrometer_dest']
+    config['dest_port'] = dest_port or config['dest_port']
+
+    if usetapcp:
+        transport = casperfpga.TapcpTransport
+    else:
+        transport = casperfpga.KatcpTransport
+
+    logger.info("Connecting to %s" % host)
+    feng = ata_snap_fengine.AtaSnapFengine(host,
+            transport=transport,
+            feng_id=feng_id)
+
+    if not skipprog:
+        logger.info("Programming %s with %s" % (host, fpgfile))
+        feng.program(fpgfile)
+    else:
+        logger.info("Skipping programming because the --skipprog flag was used")
+        # If we're not programming we need to load the FPG information
+        feng.fpga.get_system_information(fpgfile)
+
+    # Disable ethernet output before doing anything
+    feng.eth_enable_output(False)
+
+    feng.set_accumulation_length(config['acclen'])
+
+    # Use the same coefficients for both polarizations
+    feng.eq_load_coeffs(0, config['coeffs'])
+    feng.eq_load_coeffs(1, config['coeffs'])
+
+    feng.eq_load_test_vectors(0, list(range(feng.n_chans_f)))
+    feng.eq_load_test_vectors(1, list(range(feng.n_chans_f)))
+    feng.eq_test_vector_mode(enable=tvg)
+    feng.spec_test_vector_mode(enable=tvg)
+
+    # Configure arp table
+    for ip, mac in config['arp'].items():
+        print ("Configuring ip: %s with mac: %x" %(ip, mac))
+        for ethn, eth in enumerate(feng.fpga.gbes):
+            eth.set_single_arp_entry(ip, mac)
+
+    voltage_config = config.get('voltage_output', None)
+    n_interfaces = voltage_config.get('n_interfaces', feng.n_interfaces)
+    for i in range(n_interfaces):
+        ip = config["interfaces"][feng.fpga.host][i]
+        mac = config["arp"][ip]
+        port = 10000
+        eth = feng.fpga.gbes['eth%i_core' %i]
+        eth.configure_core(mac, ip, port)
+
+    if eth_spec:
+        feng.spec_set_destination(config['spectrometer_dest'])
+
+    if voltage_config is not None:
+        n_chans = voltage_config['n_chans']
+        start_chan = voltage_config['start_chan']
+        dests = voltage_config['dests']
+        logger.info('Voltage output sending channels %d to %d' % (start_chan, start_chan+n_chans-1))
+        logger.info('Destination IPs: %s' %dests)
+        logger.info('Using %d interfaces' % n_interfaces)
+        feng.select_output_channels(start_chan, n_chans, dests, n_interfaces=n_interfaces)
+
+    feng.eth_set_dest_port(config['dest_port'])
+
+    if eth_spec:
+        feng.eth_set_mode('spectra')
+        feng.fpga.write_int('corr_feng_id', feng_id)
+    elif eth_volt:
+        feng.eth_set_mode('voltage')
+
+    if sync:
+        if not mansync:
+            feng.sync_wait_for_pps()
+        feng.sync_arm(manual_trigger=mansync)
+
+    # Reset ethernet cores prior to enabling
+    feng.eth_reset()
+    if eth_spec or eth_volt:
+        logger.info('Enabling Ethernet output')
+        feng.eth_enable_output(True)
+    else:
+        logger.info('Not enabling Ethernet output, since neither voltage or spectrometer 10GbE output flags were set.')
+
+    logger.info("Initialization complete!")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Program and initialize a SNAP ADC5G spectrometer',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('host', type=str,
-                    help = 'Hostname / IP of SNAP')
-parser.add_argument('fpgfile', type=str, 
-                    help = '.fpgfile to program')
-parser.add_argument('configfile', type=str,
-                    help ='Configuration file')
-parser.add_argument('-s', dest='sync', action='store_true', default=False,
-                    help ='Use this flag to re-arm the design\'s sync logic')
-parser.add_argument('-m', dest='mansync', action='store_true', default=False,
-                    help ='Use this flag to issue an internal sync rather than using a PPS')
-parser.add_argument('-t', dest='tvg', action='store_true', default=False,
-                    help ='Use this flag to switch to post-fft test vector outputs')
-parser.add_argument('-i', dest='feng_id', type=int,
-                    default=0, help='F-engine ID to write to this SNAP\'s output packets')
-parser.add_argument('-p', dest='dest_port', type=int,
-                    default=None, help='10GBe destination port')
-parser.add_argument('--skipprog', dest='skipprog', action='store_true', default=False,
-                    help='Skip programming .fpg file')
-parser.add_argument('--usetapcp', dest='usetapcp', action='store_true', default=False,
-                    help='Use Tapcp protocol to connect to the SNAP')
-parser.add_argument('--eth_spec', dest='eth_spec', action='store_true', default=False,
-                    help ='Use this flag to switch on Ethernet transmission of the spectrometer')
-parser.add_argument('--eth_volt', dest='eth_volt', action='store_true', default=False,
-                    help ='Use this flag to switch on Ethernet transmission of F-engine data')
-parser.add_argument('-a', dest='acclen', type=int, default=None,
-                    help ='Number of spectra to accumulate per spectrometer dump. Default: get from config file')
-parser.add_argument('--specdest', dest='specdest', type=str, default=None,
-        help ='Destination IP address to which spectra should be sent. Default: get from config file')
+    parser.add_argument('host', type=str,
+                        help = 'Hostname / IP of SNAP')
+    parser.add_argument('fpgfile', type=str, 
+                        help = '.fpgfile to program')
+    parser.add_argument('configfile', type=str,
+                        help ='Configuration file')
+    parser.add_argument('-s', dest='sync', action='store_true', default=False,
+                        help ='Use this flag to re-arm the design\'s sync logic')
+    parser.add_argument('-m', dest='mansync', action='store_true', default=False,
+                        help ='Use this flag to issue an internal sync rather than using a PPS')
+    parser.add_argument('-t', dest='tvg', action='store_true', default=False,
+                        help ='Use this flag to switch to post-fft test vector outputs')
+    parser.add_argument('-i', dest='feng_id', type=int,
+                        default=0, help='F-engine ID to write to this SNAP\'s output packets')
+    parser.add_argument('-p', dest='dest_port', type=int,
+                        default=None, help='10GBe destination port')
+    parser.add_argument('--skipprog', dest='skipprog', action='store_true', default=False,
+                        help='Skip programming .fpg file')
+    parser.add_argument('--usetapcp', dest='usetapcp', action='store_true', default=False,
+                        help='Use Tapcp protocol to connect to the SNAP')
+    parser.add_argument('--eth_spec', dest='eth_spec', action='store_true', default=False,
+                        help ='Use this flag to switch on Ethernet transmission of the spectrometer')
+    parser.add_argument('--eth_volt', dest='eth_volt', action='store_true', default=False,
+                        help ='Use this flag to switch on Ethernet transmission of F-engine data')
+    parser.add_argument('-a', dest='acclen', type=int, default=None,
+                        help ='Number of spectra to accumulate per spectrometer dump. Default: get from config file')
+    parser.add_argument('--specdest', dest='specdest', type=str, default=None,
+            help ='Destination IP address to which spectra should be sent. Default: get from config file')
 
-args = parser.parse_args()
+    args = parser.parse_args()
 
-logger = logging.getLogger(__file__)
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.INFO)
-logger.addHandler(handler)
-
-assert not (args.eth_spec and args.eth_volt), "Can't use both --eth_spec and --eth_volt options!"
-
-# Load configuration file and override parameters with
-# user flags
-with open(args.configfile, 'r') as fh:
-    config = yaml.load(fh, Loader=yaml.SafeLoader)
-
-config['acclen'] = args.acclen or config['acclen']
-config['spectrometer_dest'] = args.specdest or config['spectrometer_dest']
-config['dest_port'] = args.dest_port or config['dest_port']
-
-if args.usetapcp:
-    transport = casperfpga.TapcpTransport
-else:
-    transport = casperfpga.KatcpTransport
-
-logger.info("Connecting to %s" % args.host)
-feng = ata_snap_fengine.AtaSnapFengine(args.host,
-        transport=transport,
-        feng_id=args.feng_id)
-
-if not args.skipprog:
-    logger.info("Programming %s with %s" % (args.host, args.fpgfile))
-    feng.program(args.fpgfile)
-else:
-    logger.info("Skipping programming because the --skipprog flag was used")
-    # If we're not programming we need to load the FPG information
-    feng.fpga.get_system_information(args.fpgfile)
-
-# Disable ethernet output before doing anything
-feng.eth_enable_output(False)
-
-feng.set_accumulation_length(config['acclen'])
-
-# Use the same coefficients for both polarizations
-feng.eq_load_coeffs(0, config['coeffs'])
-feng.eq_load_coeffs(1, config['coeffs'])
-
-feng.eq_load_test_vectors(0, list(range(feng.n_chans_f)))
-feng.eq_load_test_vectors(1, list(range(feng.n_chans_f)))
-feng.eq_test_vector_mode(enable=args.tvg)
-feng.spec_test_vector_mode(enable=args.tvg)
-
-# Configure arp table
-for ip, mac in config['arp'].items():
-    print ("Configuring ip: %s with mac: %x" %(ip, mac))
-    for ethn, eth in enumerate(feng.fpga.gbes):
-        eth.set_single_arp_entry(ip, mac)
-
-voltage_config = config.get('voltage_output', None)
-n_interfaces = voltage_config.get('n_interfaces', feng.n_interfaces)
-for i in range(n_interfaces):
-    ip = config["interfaces"][feng.fpga.host][i]
-    mac = config["arp"][ip]
-    port = 10000
-    eth = feng.fpga.gbes['eth%i_core' %i]
-    eth.configure_core(mac, ip, port)
-
-if args.eth_spec:
-    feng.spec_set_destination(config['spectrometer_dest'])
-
-if voltage_config is not None:
-    n_chans = voltage_config['n_chans']
-    start_chan = voltage_config['start_chan']
-    dests = voltage_config['dests']
-    logger.info('Voltage output sending channels %d to %d' % (start_chan, start_chan+n_chans-1))
-    logger.info('Destination IPs: %s' %dests)
-    logger.info('Using %d interfaces' % n_interfaces)
-    feng.select_output_channels(start_chan, n_chans, dests, n_interfaces=n_interfaces)
-
-feng.eth_set_dest_port(config['dest_port'])
-
-if args.eth_spec:
-    feng.eth_set_mode('spectra')
-    feng.fpga.write_int('corr_feng_id', args.feng_id)
-elif args.eth_volt:
-    feng.eth_set_mode('voltage')
-
-if args.sync:
-    if not args.mansync:
-        feng.sync_wait_for_pps()
-    feng.sync_arm(manual_trigger=args.mansync)
-
-# Reset ethernet cores prior to enabling
-feng.eth_reset()
-if args.eth_spec or args.eth_volt:
-    logger.info('Enabling Ethernet output')
-    feng.eth_enable_output(True)
-else:
-    logger.info('Not enabling Ethernet output, since neither voltage or spectrometer 10GbE output flags were set.')
-
-logger.info("Initialization complete!")
+    run(args.host, args.fpgfile, args.configfile,
+        sync=args.sync,
+        mansync=args.mansync,
+        tvg=args.tvg,
+        feng_id=args.feng_id,
+        dest_port=args.dest_port,
+        skipprog=args.skipprog,
+        usetapcp=args.usetapcp,
+        eth_spec=args.eth_spec,
+        eth_volt=args.eth_volt,
+        acclen=args.acclen,
+        specdest=args.specdest
+        )

--- a/sw/ata_snap/src/ata_snap_fengine.py
+++ b/sw/ata_snap/src/ata_snap_fengine.py
@@ -1291,16 +1291,16 @@ class AtaSnapFengine(object):
         # For now, we only consider case with time the faster axis.
         times_per_word = 64 // (2*2*n_bits)
         # This should always be True for reasonable firmware
-        assert self.packetizer_granularity % times_per_word == 0
+        assert self.packetizer_granularity % times_per_word == 0, "{} % {} != 0".format(self.packetizer_granularity, times_per_word)
         packetizer_chan_granularity = self.packetizer_granularity // times_per_word
 
         # We reorder n_chans_per_block as parallel words, so must deal with
         # start / stop points with that granularity
-        assert start_chan % self.n_chans_per_block == 0
+        assert start_chan % self.n_chans_per_block == 0, "{} % {} != 0".format(start_chan, self.n_chans_per_block)
         n_dests = len(dests)
         # Also Demand that the number of channels can be equally divided
         # among the destination addresses
-        assert n_chans % (n_dests * self.n_chans_per_block) == 0
+        assert n_chans % (n_dests * self.n_chans_per_block) == 0, "{} % {} != 0".format(n_chans, (n_dests * self.n_chans_per_block))
         # Number of channels per destination is now gauranteed to be an integer
         # multiple of n_chans_per_block
         n_chans_per_destination = n_chans // n_dests
@@ -1308,15 +1308,15 @@ class AtaSnapFengine(object):
         # packets
         n_packets_per_destination = int(np.ceil(n_chans_per_destination / max_chans_per_packet))
         # Channels should be able to be divided up into packets equally
-        assert n_chans_per_destination % n_packets_per_destination == 0
+        assert n_chans_per_destination % n_packets_per_destination == 0, "{} % {} != 0".format(n_chans_per_destination, n_packets_per_destination)
         n_chans_per_packet = n_chans_per_destination  // n_packets_per_destination
         # Number of channels per packet should be a multiple of the reorder granularity
-        assert n_chans_per_packet % self.n_chans_per_block == 0
+        assert n_chans_per_packet % self.n_chans_per_block == 0, "{} % {} != 0".format(n_chans_per_packet, self.n_chans_per_block)
         # Number of channels per packet should be a multiple of packetizer granularity
-        assert n_chans_per_packet % packetizer_chan_granularity == 0
+        assert n_chans_per_packet % packetizer_chan_granularity == 0, "{} % {} != 0".format(n_chans_per_packet, packetizer_chan_granularity)
         n_slots_per_packet = n_chans_per_packet // packetizer_chan_granularity
         # Can't send more than all the channels!
-        assert start_chan + n_chans <= self.n_chans_f
+        assert start_chan + n_chans <= self.n_chans_f, "{} > {}".format(start_chan + n_chans, self.n_ch)
 
         self.logger.info('Start channel: %d' % start_chan)
         self.logger.info('Number of channels to send: %d' % n_chans)
@@ -1361,7 +1361,7 @@ class AtaSnapFengine(object):
         # How many slots packetizer blocks do we need to use?
         # Lazily force data rate out of each interface to be the same
         n_packets = len(dup_dests)
-        assert n_packets % n_interfaces == 0, "Number of destination packets (%d) does not divide evenly betweed %d interfaces" % n(n_packets, _interfaces)
+        assert n_packets % n_interfaces == 0, "Number of destination packets (%d) does not divide evenly betweed %d interfaces" % (n_packets, n_interfaces)
         available_blocks = packetizer_n_blocks * n_interfaces
         needed_blocks = n_chans // packetizer_chan_granularity
         spare_blocks = available_blocks - needed_blocks


### PR DESCRIPTION
Wrapped the `snap_feng_init.py` core content in `run()`, with an `if __name__=='__main__':  run(argparse)`, enabling importing the script in higher-level scripts.

Added assertion messages to the `select_output_channels()` function in `ata_snap_fengine.py`.