### PR TITLE
RFSoC_init.py no default dest_port value, fallback on config file

### DIFF
--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -15,7 +15,7 @@ def run(host, fpgfile, configfile,
         tvg=False,
         feng_ids='0,1,2,3',
         pipeline_ids='0,1,2,3',
-        dest_port='10000,10001,10002,10003,10004,10005,10006,10007',
+        dest_port=None,
         skipprog=False,
         eth_spec=False,
         noblank=False,
@@ -202,8 +202,8 @@ if __name__ == '__main__':
     parser.add_argument('-j', dest='pipeline_ids', type=str, default='0,1,2,3',
                         help='Comma separated list of pipeline IDs to associate an F-eng with a pipeline instance')
     parser.add_argument('-p', dest='dest_port', type=str,
-                        default='10000,10001,10002,10003,10004,10005,10006,10007',
-                        help='Comma-separated 100 GBe destination ports. One per F-engine')
+                        default=None,
+                        help='Comma-separated 100 GBe destination ports. One per F-engine [defaults to config file].')
     parser.add_argument('--skipprog', dest='skipprog', action='store_true', default=False,
                         help='Skip programming .fpg file')
     parser.add_argument('--eth_spec', dest='eth_spec', action='store_true', default=False,


### PR DESCRIPTION
- no default dest_port value so that fallback of dest_port in config file isn't overridden