### PR TITLE
Rfsoc 8bit multidest config

### DIFF
--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -143,13 +143,17 @@ def run(host, fpgfile, configfile,
                 feng_dests = dests if not dests_is_antgroup_list_of_dests else dests[fn]
                 output = feng.select_output_channels(start_chan, n_chans, feng_dests, n_interfaces=n_interfaces, dest_ports=dest_port, nchans_per_packet_limit=chans_per_packet_limit)
                 print(output)
+            
+            used_pipeline_ids = [feng.pipeline_id for feng in fengs]
+            unused_pipeline_ids = [pipe_id for pipe_id in range(0, fengs[-1].n_ants_per_board) if pipe_id not in used_pipeline_ids]
+            logger.info('Unused Pipeline IDs: {}'.format(unused_pipeline_ids))
             # hack to fill in channel reorder map for unused F-engines
             orig_pipeline_id = fengs[-1].pipeline_id
             orig_feng_id = fengs[-1].feng_id
-            for fn, pipeline_id in enumerate(range(orig_pipeline_id+1, fengs[-1].n_ants_per_board)):
+            for pipeline_id in unused_pipeline_ids:
                 print("blanking out pipeline id %d" % pipeline_id)
                 dest_port = config['dest_port'][pipeline_id] if isinstance(config['dest_port'], list) else config['dest_port']
-                feng_dests = dests if not dests_is_antgroup_list_of_dests else dests[fn]
+                feng_dests = dests if not dests_is_antgroup_list_of_dests else dests[0] # doesn't really matter
                 fengs[-1].feng_id = -1
                 fengs[-1].pipeline_id = pipeline_id
                 fengs[-1]._calc_output_ids()

--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -132,13 +132,14 @@ def run(host, fpgfile, configfile,
             start_chan = voltage_config['start_chan']
             dests = voltage_config['dests']
             dests_is_antgroup_list_of_dests = isinstance(dests[0], list)
+            chans_per_packet_limit = voltage_config['limit_chans_per_packet'] if 'limit_chans_per_packet'  in voltage_config else None
             logger.info('Voltage output sending channels %d to %d' % (start_chan, start_chan+n_chans-1))
             logger.info('Destination IPs: %s' %dests)
             logger.info('Using %d interfaces' % n_interfaces)
             for fn, feng in enumerate(fengs):
                 dest_port = config['dest_port'][fn] if isinstance(config['dest_port'], list) else config['dest_port']
                 feng_dests = dests if not dests_is_antgroup_list_of_dests else dests[fn]
-                output = feng.select_output_channels(start_chan, n_chans, feng_dests, n_interfaces=n_interfaces, dest_ports=dest_port)
+                output = feng.select_output_channels(start_chan, n_chans, feng_dests, n_interfaces=n_interfaces, dest_ports=dest_port, nchans_per_packet_limit=chans_per_packet_limit)
                 print(output)
             # hack to fill in channel reorder map for unused F-engines
             orig_pipeline_id = fengs[-1].pipeline_id
@@ -150,7 +151,7 @@ def run(host, fpgfile, configfile,
                 fengs[-1].feng_id = -1
                 fengs[-1].pipeline_id = pipeline_id
                 fengs[-1]._calc_output_ids()
-                fengs[-1].select_output_channels(start_chan, n_chans, feng_dests, n_interfaces=n_interfaces, dest_ports=dest_port, blank=not noblank)
+                fengs[-1].select_output_channels(start_chan, n_chans, feng_dests, n_interfaces=n_interfaces, dest_ports=dest_port, blank=not noblank, nchans_per_packet_limit=chans_per_packet_limit)
             fengs[-1].pipeline_id = orig_pipeline_id
             fengs[-1].feng_id = orig_feng_id
             fengs[-1]._calc_output_ids()

--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -22,7 +22,8 @@ def run(host, fpgfile, configfile,
         eth_volt=False,
         acclen=250000,
         testmode=False,
-        specdest=None
+        specdest=None,
+        dests=None
         ):
     logger = logging.getLogger(__file__)
     logger.setLevel(logging.INFO)
@@ -41,6 +42,7 @@ def run(host, fpgfile, configfile,
     config['dest_port'] = dest_port or config['dest_port']
     if isinstance(config['dest_port'], str):
         config['dest_port'] = list(map(int, config['dest_port'].split(',')))
+    config['voltage_output']['dests'] = dests or config['voltage_output']['dests']
 
     logger.info("Connecting to %s" % host)
     fengs = []

--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -211,6 +211,8 @@ if __name__ == '__main__':
                         help='List of F-engine IDs to write to this SNAP\'s output packets')
     parser.add_argument('-j', dest='pipeline_ids', type=int, nargs='*', default=[0,1,2,3],
                         help='List of pipeline IDs to associate an F-eng with a pipeline instance')
+    parser.add_argument('-d', dest='dests', type=str, nargs='*', default=None,
+                        help='List of the packets\' destination IP addresses (Nested lists are comma (\",\") delimited)')
     parser.add_argument('-p', dest='dest_port', type=str,
                         default=None,
                         help='Comma-separated 100 GBe destination ports. One per F-engine [defaults to config file].')
@@ -231,6 +233,14 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    assert len(args.pipeline_ids) == len(args.feng_ids), 'There must be as many Pipeline IDs ({}) as there are F-Eng IDs. ({})'.format(len(args.pipeline_ids), len(args.feng_ids))
+
+    if args.dests is not None:
+        dests_are_nested = any([',' in dests for dests in args.dests])
+        if dests_are_nested:
+            assert len(args.dests) == len(args.pipeline_ids), 'Nested destination IPs provided, but not enough for each of {} pipelines in use.'.format(len(args.pipeline_ids))
+            args.dests = [dests.split(',') for dests in args.dests]
+
     run(args.host, args.fpgfile, args.configfile,
         sync=args.sync,
         mansync=args.mansync,
@@ -238,6 +248,7 @@ if __name__ == '__main__':
         feng_ids=args.feng_ids,
         pipeline_ids=args.pipeline_ids,
         dest_port=args.dest_port,
+        dests=args.dests,
         skipprog=args.skipprog,
         eth_spec=args.eth_spec,
         noblank=args.noblank,

--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -108,7 +108,7 @@ def run(host, fpgfile, configfile,
     if eth_spec or eth_volt:
         # Configure arp table
         for ip, mac in config['arp'].items():
-            print ("Configuring ip: %s with mac: %x" %(ip, mac))
+            print ("Configuring ip: %s with mac: %012x" %(ip, mac))
             for ethn, eth in enumerate(fengs[0].fpga.gbes):
                 eth.set_single_arp_entry(ip, mac)
 

--- a/sw/ata_snap/scripts/rfsoc_feng_init.py
+++ b/sw/ata_snap/scripts/rfsoc_feng_init.py
@@ -38,7 +38,6 @@ def run(host, fpgfile, configfile,
         config = yaml.load(fh, Loader=yaml.SafeLoader)
 
     config['acclen'] = acclen or config['acclen']
-    config['spectrometer_dest'] = specdest or config['spectrometer_dest']
     config['dest_port'] = dest_port or config['dest_port']
     if isinstance(config['dest_port'], str):
         config['dest_port'] = list(map(int, config['dest_port'].split(',')))
@@ -122,6 +121,7 @@ def run(host, fpgfile, configfile,
             eth.configure_core(mac, ip, port)
 
     if eth_spec:
+        config['spectrometer_dest'] = specdest or config['spectrometer_dest']
         for feng in fengs:
             feng.spec_set_pipeline_id()
             feng.spec_set_destination(config['spectrometer_dest'])

--- a/sw/ata_snap/src/ata_rfsoc_fengine.py
+++ b/sw/ata_snap/src/ata_rfsoc_fengine.py
@@ -655,11 +655,7 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
         # send to that address.
         rv = {}
         for dn, d in enumerate(dests):
-            print("destination", d)
-            print("offset chan", start_chan + dn*n_chans_per_packet)
-            print("end chan", start_chan + (dn+1)*n_chans_per_packet)
-            rv[d] = list(range(start_chan + dn*n_chans_per_packet,
-                          start_chan + (dn+1)*n_chans_per_packet))
+            rv[d] = {'start_chan':start_chan + dn*n_chans_per_destination, 'end_chan':start_chan + (dn+1)*n_chans_per_destination}
         return rv
 
     def _populate_headers(self, interface, headers, offset=0):

--- a/sw/ata_snap/src/ata_rfsoc_fengine.py
+++ b/sw/ata_snap/src/ata_rfsoc_fengine.py
@@ -405,6 +405,7 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
         :type dests: list of str
 
         :param dest_ports: List of destination UDP ports to which data should be sent.
+            If it is a scalar, a list of duplicates is used.
             The first n_chans / len(dests) will be sent to dest[0], etc..
             The length of this list should be the same as the length of the ``dests`` list.
         :type dests: list of int

--- a/sw/ata_snap/src/ata_rfsoc_fengine.py
+++ b/sw/ata_snap/src/ata_rfsoc_fengine.py
@@ -486,7 +486,7 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
         # in blocks of packetizer_granularity 64-bit words.
         # For now, we only consider case with time the faster axis.
         times_per_word = self.tge_n_bytes_per_word // (2*2*n_bits // 8)
-        assert times_per_word % self.n_times_per_packet == 0
+        assert self.packetizer_granularity % times_per_word == 0, 'self.packetizer_granularity % times_per_word ({} % {}) != 0'.format(self.packetizer_granularity, times_per_word)
         chans_per_word = times_per_word // self.n_times_per_packet
         self.logger.info("Samples per packetizer word: %d" % times_per_word)
         self.logger.info("Channels per packetizer word: %d" % chans_per_word)
@@ -495,7 +495,7 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
 
         # We reorder n_chans_per_block as parallel words, so must deal with
         # start / stop points with that granularity
-        assert start_chan % self.n_chans_per_block == 0
+        assert start_chan % self.n_chans_per_block == 0, 'start_chan % self.n_chans_per_block ({} % {}) != 0'.format(start_chan, self.n_chans_per_block)
         n_dests = len(dests)
         self.logger.info("Number of destination addresses is: %d" % n_dests)
         self.logger.info("Number of channels to be sent is: %d" % n_chans)
@@ -504,7 +504,7 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
         self.logger.info("Channels per block is: %d" % self.n_chans_per_block)
         # Also Demand that the number of channels can be equally divided
         # among the destination addresses
-        assert n_chans % (n_dests * self.n_chans_per_block) == 0
+        assert n_chans % (n_dests * self.n_chans_per_block) == 0, 'n_chans % (n_dests * self.n_chans_per_block) ({} % {}) != 0'.format(n_chans, (n_dests * self.n_chans_per_block))
         # Number of channels per destination is now gauranteed to be an integer
         # multiple of n_chans_per_block
         n_chans_per_destination = n_chans // n_dests
@@ -514,16 +514,16 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
         n_packets_per_destination = int(np.ceil(n_chans_per_destination / max_chans_per_packet))
         self.logger.info("Number of packets per destination is: %d" % n_packets_per_destination)
         # Channels should be able to be divided up into packets equally
-        assert n_chans_per_destination % n_packets_per_destination == 0
+        assert n_chans_per_destination % n_packets_per_destination == 0, 'n_chans_per_destination % n_packets_per_destination ({} % {}) != 0'.format(n_chans_per_destination, n_packets_per_destination)
         n_chans_per_packet = n_chans_per_destination  // n_packets_per_destination
         # Number of channels per packet should be a multiple of the reorder granularity
-        assert n_chans_per_packet % self.n_chans_per_block == 0
+        assert n_chans_per_packet % self.n_chans_per_block == 0, 'n_chans_per_packet % self.n_chans_per_block ({} % {}) != 0'.format(n_chans_per_packet, self.n_chans_per_block)
         # Number of channels per packet should be a multiple of packetizer granularity
         self.logger.info('Number of channels per packet: %d' % n_chans_per_packet)
-        assert n_chans_per_packet % packetizer_chan_granularity == 0
+        assert n_chans_per_packet % packetizer_chan_granularity == 0, 'n_chans_per_packet % packetizer_chan_granularity ({} % {}) != 0'.format(n_chans_per_packet, packetizer_chan_granularity)
         n_slots_per_packet = n_chans_per_packet // packetizer_chan_granularity
         # Can't send more than all the channels!
-        assert start_chan + n_chans <= self.n_chans_f
+        assert start_chan + n_chans <= self.n_chans_f, 'start_chan + n_chans > self.n_chans_f ({} > {})'.format(start_chan + n_chans, self.n_chans_f)
 
         self.logger.info('Start channel: %d' % start_chan)
         self.logger.info('Number of channels to send: %d' % n_chans)

--- a/sw/ata_snap/src/ata_rfsoc_fengine.py
+++ b/sw/ata_snap/src/ata_rfsoc_fengine.py
@@ -53,7 +53,11 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
             self.spec_set_pipeline_id()
         except:
             pass
-        self._read_parameters_from_fpga()
+        try:
+            # fpga.listdev() can fail if the board has no image
+            self._read_parameters_from_fpga()
+        except:
+            pass
         self._calc_output_ids()
 
         # If the board is programmed, try to get the fpg data

--- a/sw/ata_snap/src/ata_rfsoc_fengine.py
+++ b/sw/ata_snap/src/ata_rfsoc_fengine.py
@@ -462,8 +462,10 @@ class AtaRfsocFengine(ata_snap_fengine.AtaSnapFengine):
         # spectra using a programmable reorder. This reorder operates on
         # n_chans_f * n_times_per_packet / nchans_per_block words, with each word
         # 8+8 bits x nchans_per_block x 2 [pols] wide.
-
-        assert len(dests) == len(dest_ports), "Length of ``dests`` list and ``dest_ports`` list must be the same"
+        if isinstance(dest_ports, list):
+            assert len(dests) == len(dest_ports), "Length of ``dests`` list and ``dest_ports`` list must be the same"
+        else:
+            dest_ports = [dest_ports for _ in range(len(dests))]
 
         # In RFSoC designs, all channels transit a single interface.
         # Multiple interface may be used for different antennas, but that is accomodated elsewhere

--- a/sw/ata_snap/src/ata_snap_fengine.py
+++ b/sw/ata_snap/src/ata_snap_fengine.py
@@ -1326,7 +1326,7 @@ class AtaSnapFengine(object):
             self._populate_headers(interface, headers)
         
 
-    def select_output_channels(self, start_chan, n_chans, dests=['0.0.0.0'], n_interfaces=None, n_bits=4):
+    def select_output_channels(self, start_chan, n_chans, dests=['0.0.0.0'], n_interfaces=None, n_bits=4, nchans_per_packet_limit=None):
         """
         Select the range of channels which the voltage pipeline should output.
 
@@ -1346,6 +1346,9 @@ class AtaSnapFengine(object):
         :param n_interfaces: Number of 10GbE interfaces to use. Should be <= self.n_interfaces
             Default to using all available interfaces.
         :type n_interface: int
+        :param nchans_per_packet_limit: If not None, limits the number of channels per packet to
+            min(nchans_per_packet_limit, actual-maximum).
+        :type nchans_per_packet_limit: int
 
         :raises AssertionError: If the following conditions aren't met:
             `start_chan` should be a multiple of self.n_chans_per_block (4)
@@ -1407,6 +1410,8 @@ class AtaSnapFengine(object):
         # size is 8 kByte + header
         assert n_bits in [4,8], "Only 4- or 8-bit output modes are supported!"
         max_chans_per_packet = 8*8192 // (2*n_bits) // self.n_times_per_packet // 2
+        if nchans_per_packet_limit is not None:
+            max_chans_per_packet = min(max_chans_per_packet, nchans_per_packet_limit)
 
         if n_bits == 8:
             raise NotImplementedError("8-bit mode not yet implemented")

--- a/sw/ata_snap/src/ata_snap_fengine.py
+++ b/sw/ata_snap/src/ata_snap_fengine.py
@@ -1427,16 +1427,16 @@ class AtaSnapFengine(object):
         # For now, we only consider case with time the faster axis.
         times_per_word = 64 // (2*2*n_bits)
         # This should always be True for reasonable firmware
-        assert self.packetizer_granularity % times_per_word == 0
+        assert self.packetizer_granularity % times_per_word == 0, 'self.packetizer_granularity % times_per_word ({} % {}) != 0'.format(self.packetizer_granularity, times_per_word)
         packetizer_chan_granularity = self.packetizer_granularity // times_per_word
 
         # We reorder n_chans_per_block as parallel words, so must deal with
         # start / stop points with that granularity
-        assert start_chan % self.n_chans_per_block == 0
+        assert start_chan % self.n_chans_per_block == 0, 'start_chan % self.n_chans_per_block ({} % {}) != 0'.format(start_chan, self.n_chans_per_block)
         n_dests = len(dests)
         # Also Demand that the number of channels can be equally divided
         # among the destination addresses
-        assert n_chans % (n_dests * self.n_chans_per_block) == 0
+        assert n_chans % (n_dests * self.n_chans_per_block) == 0, 'n_chans % (n_dests * self.n_chans_per_block) ({} % {}) != 0'.format(n_chans, (n_dests * self.n_chans_per_block))
         # Number of channels per destination is now gauranteed to be an integer
         # multiple of n_chans_per_block
         n_chans_per_destination = n_chans // n_dests
@@ -1444,15 +1444,15 @@ class AtaSnapFengine(object):
         # packets
         n_packets_per_destination = int(np.ceil(n_chans_per_destination / max_chans_per_packet))
         # Channels should be able to be divided up into packets equally
-        assert n_chans_per_destination % n_packets_per_destination == 0
+        assert n_chans_per_destination % n_packets_per_destination == 0, 'n_chans_per_destination % n_packets_per_destination ({} % {}) != 0'.format(n_chans_per_destination, n_packets_per_destination)
         n_chans_per_packet = n_chans_per_destination  // n_packets_per_destination
         # Number of channels per packet should be a multiple of the reorder granularity
-        assert n_chans_per_packet % self.n_chans_per_block == 0
+        assert n_chans_per_packet % self.n_chans_per_block == 0, 'n_chans_per_packet % self.n_chans_per_block ({} % {}) != 0'.format(n_chans_per_packet, self.n_chans_per_block)
         # Number of channels per packet should be a multiple of packetizer granularity
-        assert n_chans_per_packet % packetizer_chan_granularity == 0
+        assert n_chans_per_packet % packetizer_chan_granularity == 0, 'n_chans_per_packet % packetizer_chan_granularity ({} % {}) != 0'.format(n_chans_per_packet, packetizer_chan_granularity)
         n_slots_per_packet = n_chans_per_packet // packetizer_chan_granularity
         # Can't send more than all the channels!
-        assert start_chan + n_chans <= self.n_chans_f
+        assert start_chan + n_chans <= self.n_chans_f, 'start_chan + n_chans > self.n_chans_f ({} > {})'.format(start_chan + n_chans, self.n_chans_f)
 
         self.logger.info('Start channel: %d' % start_chan)
         self.logger.info('Number of channels to send: %d' % n_chans)


### PR DESCRIPTION
Effectively #35 for 8bit.

The primary ability is to add a pipeline-indexed list of destinations, so that one can specify destinations for each pipeline... I may have jumped the gun in thinking that this was possible....

Will mark ready for review once the issues relating to this at the ATA are resolved.